### PR TITLE
added autocmd to update watch window (if opened) on save

### DIFF
--- a/ftplugin/ls.vim
+++ b/ftplugin/ls.vim
@@ -168,6 +168,7 @@ function! s:LiveScriptCompile(startline, endline, args)
 
     augroup LiveScriptCompileAuWatch
       autocmd InsertLeave <buffer> call s:LiveScriptCompileWatchUpdate()
+      autocmd BufWritePost <buffer> call s:LiveScriptCompileWatchUpdate()
     augroup END
   else
     call s:LiveScriptCompileUpdate(a:startline, a:endline)


### PR DESCRIPTION
It's a very tiny addition, but I sometimes find it annoying that, if make a change that doesn't require me to enter insert mode (deleting or moving a line for example), I need to enter and leave insert mode just to view the changes.  This is a small adjustment that I have made for myself, that I thought might help others.
