### PR TITLE
fix not indenting after `do` keyword

### DIFF
--- a/indent/ls.vim
+++ b/indent/ls.vim
@@ -29,7 +29,7 @@ let s:INDENT_AFTER_KEYWORD = '^\%(if\|unless\|else\|for\|while\|until\|'
 let s:INDENT_AFTER_OPERATOR = '\%([([{:=]\|[-=]>\)$'
 
 " Keywords and operators that continue a line
-let s:CONTINUATION = '\<\%(is\|isnt\|and\|or\)\>$'
+let s:CONTINUATION = '\<\%(is\|isnt\|and\|or\|do\)\>$'
 \                  . '\|'
 \                  . '\%(-\@<!-\|+\@<!+\|<\|[-~]\@<!>\|\*\|/\@<!/\|%\||\|'
 \                  . '&\|,\|\.\@<!\.\)$'


### PR DESCRIPTION
previously <CR> after a `do` in the end of the line would not indent the next
line, this fixes it.
